### PR TITLE
临时关闭registerItemsViewMenu可临时规避右键卡顿

### DIFF
--- a/src/modules/menus.ts
+++ b/src/modules/menus.ts
@@ -11,7 +11,7 @@ import { NonDuplicatesDB } from "../db/nonDuplicates";
 function registerMenus(win: Window) {
   const menuManager = new ztoolkit.Menu();
   registerDuplicateCollectionMenu(menuManager);
-  registerItemsViewMenu(menuManager, win);
+  // registerItemsViewMenu(menuManager, win);
 }
 
 function registerItemsViewMenu(menuManager: MenuManager, win: Window) {


### PR DESCRIPTION
#94 

关闭此行代码可暂时规避掉右键卡顿问题，但此插件的右键内功能失效。